### PR TITLE
Auto stats (X mfrs, Y models)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ missing
 
 # NUT Website-specific
 ups-html.txt
+website.txt
 historic-release.txt
 .git-commit-website
 *.txt-spellchecked

--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,7 @@ dnl ----------------------------------------------------------------------
 AC_CONFIG_FILES([
 	protocols/Makefile
 	Makefile
+	website.txt
 ])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,14 @@ AC_SUBST(TARBALL_VERSION)
 
 dnl ----------------------------------------------------------------------
 
+# Some statistics for the front page:
+COUNT_HCL_MANUFACTURERS="$(grep -E '^"' nut/data/driver.list.in | awk -F'"' '{print $2}' | sort | uniq | wc -l)"
+COUNT_HCL_MODELS="$(grep -E '^"' nut/data/driver.list.in | awk -F'"' '{print $2" "$8" "$10}' | sort | uniq -c | wc -l)"
+AC_SUBST(COUNT_HCL_MANUFACTURERS)
+AC_SUBST(COUNT_HCL_MODELS)
+
+dnl ----------------------------------------------------------------------
+
 AC_CONFIG_FILES([
 	protocols/Makefile
 	Makefile

--- a/website.txt.in
+++ b/website.txt.in
@@ -17,18 +17,6 @@ As of this publication, at least @COUNT_HCL_MANUFACTURERS@ different
 manufacturers, and @COUNT_HCL_MODELS@ hardware device models are known as
 link:stable-hcl.html[compatible].
 
-//////////////////////////////////
-TODO: Automate the number above with Makefile magic and asciidoc variables
-or a .in style template parsing
-
-# Manufacturers:
-:; grep -E '^"' nut/data/driver.list.in | awk -F'"' '{print $2}' | sort | uniq | wc -l
-
-# Models:
-:; grep -E '^"' nut/data/driver.list.in | awk -F'"' '{print $2" "$8" "$10}' | sort | uniq -c | wc -l
-//////////////////////////////////
-
-
 This software is the combined effort of many
 link:acknowledgements.html[individuals and companies]
 with free and open source code licensed under the terms of GNU Public License

--- a/website.txt.in
+++ b/website.txt.in
@@ -13,7 +13,8 @@ uniform control and management interface. If you are just getting acquainted
 with NUT, link:features.html[that page] also explains the technical design
 and some possible set-ups.
 
-More than 170 different manufacturers, and several thousands of models are
+As of this publication, at least @COUNT_HCL_MANUFACTURERS@ different
+manufacturers, and @COUNT_HCL_MODELS@ hardware device models are known as
 link:stable-hcl.html[compatible].
 
 //////////////////////////////////


### PR DESCRIPTION
The code snippet has long been commented in the asciidoc - time to actually implement it.

Example change via the semi-generated line:
````
-More than 170 different manufacturers, and several thousands of models are [compatible].
+As of this publication, at least 174 different manufacturers, and 1141 hardware device models
+are known as [compatible].
````