### PR TITLE
Introduce work with `nut-website.dict*` files and `NUT_SPELL_DICT` customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ historic-release.txt
 *.txt-spellchecked
 *.txt.in-spellchecked
 *.asciidoc-spellchecked
+/nut-website.dict
+/nut-website.dict.bak-pre-sorting
+/nut-website.dict.sorted
+/.nut-website.dict.sorted
 /images/
 /output/
 /*.html

--- a/Makefile.am
+++ b/Makefile.am
@@ -291,7 +291,8 @@ clean-local:
 		ups-html.txt	\
 		scripts/ups_data.js
 	git checkout -f images || true
-	rm -f *-spellchecked protocols/*-spellchecked
+	rm -f *-spellchecked protocols/*-spellchecked nut-website.dict
+	rm -f nut-website.dict.bak-pre-sorting nut-website.dict.sorted .nut-website.dict.sorted
 	rm -f tools/nut-ddl.py tools/nut-hclinfo.py
 	rm -f historic-release.txt
 	rm -f .git-commit-website
@@ -617,17 +618,69 @@ SPELLCHECK_SRC = \
 	protocols/minicol.txt \
 	protocols/oneac.txt
 
-### Note: currently the NUT makefiles' implementation of spellcheck rules
-### assumes use of its own nut.dict. When it becomes possible to split it
-### out, consider adding  NUT_SPELL_DICT="$(NUT_SPELL_DICT)"  to command
-### and uncommenting the line below. If you use spellcheck-interactive and
-### add some more exceptions, be ready to commit a pull request from the
-### "nut" submodule as well (and do revise the changed dictionary so you
-### only add words and roll back anything your aspell might remove) and
+### Note: historically the NUT makefiles' implementation of spellcheck rules
+### assumes use of its own nut.dict. When it became possible to split it
+### out, we can add NUT_SPELL_DICT="$(NUT_SPELL_DICT)" to the sub-"make"
+### commands below.
+### If you use spellcheck-interactive and add some more exceptions, be ready
+### to commit a pull request from the "nut" submodule as well (if the custom
+### nut-website.dict is not used), and do revise the changed dictionary so
+### you only add words and roll back anything your aspell might remove) and
 ### to promote the submodule reference from nut-website later on.
-#NUT_SPELL_DICT = nut.dict
+NUT_SPELL_DICT =
 
-spellcheck spellcheck-interactive spellcheck-sortdict:
-	+$(MAKE) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $@
+if WITH_NUT_HISTORIC_RELEASE
+# Indented GNUmake "if/else/endif"
+ if $(or $(findstring 2.7.,$(strip $(NUT_HISTORIC_RELEASE)), $(findstring 2.8.0,$(strip $(NUT_HISTORIC_RELEASE))))
+# No-op for older releases, use only NUT dict of that era
+# (set in stone for old releases anyway)
+#
+# FIXME: Might check if 2.8.0 is already capable for this
+#  purpose? Not pressing since its nut.dict sufficed at
+#  the time of historic website build...
+#
+# NOTE: Nut source recipes have the variable for quite a
+# while, so maybe even older releases can be covered here:
+#  20149af7fc (Arnaud Quette   2012-10-10 21:23:15 +0000  91) NUT_SPELL_DICT = nut.dict
+ else
+# This historic NUT source (2.8.x or newer) is assumed modern enough
+# Practically tested since the NUT v2.8.2 release
+NUT_SPELL_DICT += nut-website.dict
+ endif
+else !WITH_NUT_HISTORIC_RELEASE
+# Current NUT source is assumed modern enough
+NUT_SPELL_DICT += nut-website.dict
+endif !WITH_NUT_HISTORIC_RELEASE
+
+nut-website.dict: $(top_builddir)/nut/docs/nut.dict nut-website.dict.addon
+	cat $^ > "$@"
+	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile NUT_SPELL_DICT="../../$(@F)" spellcheck-sortdict
+
+# Indented GNUmake "if/else/endif"
+ ifneq (,$(strip NUT_SPELL_DICT))
+export NUT_SPELL_DICT
+NUT_SPELL_DICT_OPTION = NUT_SPELL_DICT="$(NUT_SPELL_DICT)"
+
+# Find unique words in the sorted merged dictionary here vs. (pre-)sorted
+# dictionary file in NUT source - this difference is the sorted nut-website
+# specific dictionary.
+spellcheck-sortdict: nut-website.dict.addon nut-website.dict
+	@echo "$@ for NUT_SPELL_DICT=$<" >&2
+	LANG=C LC_ALL=C diff -bu nut-website.dict $(top_builddir)/nut/docs/nut.dict \
+		| grep -E '^-' | grep -Ev '^-(-- |personal_ws)' | sed 's/^-//' \
+		> nut-website.dict.addon.sorted
+	@test -s nut-website.dict.addon.sorted || { echo "ERROR: $@ for NUT_SPELL_DICT=$< yielded an empty file; we expect some unique words here!" >&2; exit 1; }
+	@mv -f nut-website.dict.addon.sorted nut-website.dict.addon
+
+ else
+# Pass to original NUT recipe and its dict file alone
+NUT_SPELL_DICT_OPTION =
+spellcheck-sortdict:
+	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $@
+ endif
+
+# Whether we have a custom dictionary or not:
+spellcheck spellcheck-interactive: $(NUT_SPELL_DICT)
+	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $(NUT_SPELL_DICT_OPTION) $@
 
 ###

--- a/Makefile.am
+++ b/Makefile.am
@@ -166,9 +166,9 @@ release: dist-files all
 
 # Generate WEBSITE_DEPS & HTML versions of man pages
 prerequisites:
-	cd nut && rm -f ChangeLog && $(MAKE) ChangeLog
-	cd nut/docs/man && $(MAKE) $(AM_MAKEFLAGS) html-man
-	cd nut/docs && $(MAKE) $(AM_MAKEFLAGS) html-chunked pdf FAQ.html solaris-usb.html
+	+cd nut && rm -f ChangeLog && $(MAKE) $(AM_MAKEFLAGS) ChangeLog
+	+cd nut/docs/man && $(MAKE) $(AM_MAKEFLAGS) html-man
+	+cd nut/docs && $(MAKE) $(AM_MAKEFLAGS) html-chunked pdf FAQ.html solaris-usb.html
 
 # Generate distribution files and GPG fingerprint (really needed?)
 # and copy them in source dir, once (keep old published releases
@@ -180,7 +180,7 @@ dist-sig-files: $(SOURCE_DIR)/@TREE_VERSION@/nut-@TARBALL_VERSION@.tar.gz.sig
 
 $(SOURCE_DIR)/@TREE_VERSION@/nut-@TARBALL_VERSION@.tar.gz:
 	cd nut && rm -f nut-*.tar.gz*
-	cd nut && $(MAKE) $(AM_MAKEFLAGS) dist dist-hash
+	+cd nut && $(MAKE) $(AM_MAKEFLAGS) dist dist-hash
 	$(MKDIR_P) $(SOURCE_DIR)/@TREE_VERSION@
 	cp -f nut/nut-@TARBALL_VERSION@.tar.gz $(SOURCE_DIR)/@TREE_VERSION@/
 	cp -f nut/nut-@TARBALL_VERSION@.tar.gz.md5 $(SOURCE_DIR)/@TREE_VERSION@/
@@ -202,7 +202,7 @@ $(SOURCE_DIR)/@TREE_VERSION@/nut-@TARBALL_VERSION@.tar.gz:
 
 # Separate chore for maintainers with a key
 $(SOURCE_DIR)/@TREE_VERSION@/nut-@TARBALL_VERSION@.tar.gz.sig: $(SOURCE_DIR)/@TREE_VERSION@/nut-@TARBALL_VERSION@.tar.gz
-	cd nut && $(MAKE) $(AM_MAKEFLAGS) dist-sig
+	+cd nut && $(MAKE) $(AM_MAKEFLAGS) dist-sig
 	cp -f nut/nut-@TARBALL_VERSION@.tar.gz.sig $(SOURCE_DIR)/@TREE_VERSION@/
 
 # Requires that local system keychain has the needed keys
@@ -270,7 +270,7 @@ $(OUTDIR): all-files
 	fi
 
 clean-local:
-	cd nut && $(MAKE) $(AM_MAKEFLAGS) clean
+	+cd nut && $(MAKE) $(AM_MAKEFLAGS) clean
 	ddlfiles="$(MFR_TARGETS)	\
 		$(subst \%,%,$(MODELS_TARGETS))	\
 		$(subst \%,%,$(MODELS_TARGETS_RAW))	\
@@ -304,7 +304,7 @@ clean-local:
 # Using one intermediate target to avoid two builds of same files
 # (and use of corrupted intermediate data) when running parallel:
 prerequisites_hcl: nut/data/driver.list.in $(srcdir)/tools/nut-hclinfo.py $(MFR_TARGETS) | prerequisites
-	cd nut/data && $(MAKE) $(AM_MAKEFLAGS) driver.list
+	+cd nut/data && $(MAKE) $(AM_MAKEFLAGS) driver.list
 	@if \
 	    python3 -c "import json,lxml"	\
 	 || python -c "import simplejson,lxml"	\
@@ -628,6 +628,6 @@ SPELLCHECK_SRC = \
 #NUT_SPELL_DICT = nut.dict
 
 spellcheck spellcheck-interactive spellcheck-sortdict:
-	$(MAKE) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $@
+	+$(MAKE) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $@
 
 ###

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -240,3 +240,7 @@ https://ci.networkupstools.org/view/InfraTasks/job/nut-website/
 ------
 :; CI_AUTOCOMMIT=true CI_AUTOPUSH=true NUT_HISTORIC_RELEASE=v2.8.0-rc3 ./ci_build.sh
 ------
+
+* The `nut-website` specific spell-checking is handled with a dynamic mix of
+  original `nut/docs/nut.dict` and custom `nut-website.dict.addon` with key
+  words specific to files in the website (including HTML and asciidoc markup).

--- a/nut-website.dict.addon
+++ b/nut-website.dict.addon
@@ -1,0 +1,1 @@
+nutwebsitedictuniquetoken


### PR DESCRIPTION
Trying to drop the need to edit dictionary in NUT source to maintain the web site.