### PR TITLE
Revisit use of merged spellchecking dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ historic-release.txt
 /nut-website.dict.bak-pre-sorting
 /nut-website.dict.sorted
 /.nut-website.dict.sorted
+/nut-website.dict.tmp
 /images/
 /output/
 /*.html

--- a/Makefile.am
+++ b/Makefile.am
@@ -657,7 +657,12 @@ nut-website.dict: $(top_builddir)/nut/docs/nut.dict nut-website.dict.addon
 	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile NUT_SPELL_DICT="../../$(@F)" spellcheck-sortdict
 
 # Indented GNUmake "if/else/endif"
- ifneq (,$(strip $(NUT_SPELL_DICT)))
+ ifeq (,$(strip $(NUT_SPELL_DICT)))
+# Pass to original NUT recipe and its dict file alone
+NUT_SPELL_DICT_OPTION =
+spellcheck-sortdict:
+	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $@
+ else
 export NUT_SPELL_DICT
 NUT_SPELL_DICT_OPTION = NUT_SPELL_DICT="$(NUT_SPELL_DICT)"
 
@@ -671,11 +676,6 @@ spellcheck-sortdict: nut-website.dict.addon nut-website.dict
 		> nut-website.dict.addon.sorted
 	@test -s nut-website.dict.addon.sorted || { echo "ERROR: $@ for NUT_SPELL_DICT=$< yielded an empty file; we expect some unique words here!" >&2; exit 1; }
 	@mv -f nut-website.dict.addon.sorted "$(abs_top_srcdir)/nut-website.dict.addon"
- else
-# Pass to original NUT recipe and its dict file alone
-NUT_SPELL_DICT_OPTION =
-spellcheck-sortdict:
-	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $@
  endif
 
 # Whether we have a custom dictionary or not:

--- a/Makefile.am
+++ b/Makefile.am
@@ -671,7 +671,6 @@ spellcheck-sortdict: nut-website.dict.addon nut-website.dict
 		> nut-website.dict.addon.sorted
 	@test -s nut-website.dict.addon.sorted || { echo "ERROR: $@ for NUT_SPELL_DICT=$< yielded an empty file; we expect some unique words here!" >&2; exit 1; }
 	@mv -f nut-website.dict.addon.sorted "$(abs_top_srcdir)/nut-website.dict.addon"
-
  else
 # Pass to original NUT recipe and its dict file alone
 NUT_SPELL_DICT_OPTION =
@@ -681,6 +680,13 @@ spellcheck-sortdict:
 
 # Whether we have a custom dictionary or not:
 spellcheck spellcheck-interactive spellcheck-report-dict-usage: $(NUT_SPELL_DICT)
+	@echo "$@ for NUT_SPELL_DICT=$<" >&2
 	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $(NUT_SPELL_DICT_OPTION) $@
+
+# Just sort the addon file, e.g. after dumping key words into it - ported from main NUT
+spellcheck-sortdict-addon: nut-website.dict.addon
+	@echo "$@ for NUT_SPELL_DICT=$<" >&2
+	@LANG=C LC_ALL=C sort -n < "$(abs_top_srcdir)/nut-website.dict.addon" > nut-website.dict.addon.sorted
+	@mv -f nut-website.dict.addon.sorted "$(abs_top_srcdir)/nut-website.dict.addon"
 
 ###

--- a/Makefile.am
+++ b/Makefile.am
@@ -670,7 +670,7 @@ spellcheck-sortdict: nut-website.dict.addon nut-website.dict
 		| grep -E '^-' | grep -Ev '^-(-- |personal_ws)' | sed 's/^-//' \
 		> nut-website.dict.addon.sorted
 	@test -s nut-website.dict.addon.sorted || { echo "ERROR: $@ for NUT_SPELL_DICT=$< yielded an empty file; we expect some unique words here!" >&2; exit 1; }
-	@mv -f nut-website.dict.addon.sorted nut-website.dict.addon
+	@mv -f nut-website.dict.addon.sorted "$(abs_top_srcdir)/nut-website.dict.addon"
 
  else
 # Pass to original NUT recipe and its dict file alone

--- a/Makefile.am
+++ b/Makefile.am
@@ -657,7 +657,7 @@ nut-website.dict: $(top_builddir)/nut/docs/nut.dict nut-website.dict.addon
 	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile NUT_SPELL_DICT="../../$(@F)" spellcheck-sortdict
 
 # Indented GNUmake "if/else/endif"
- ifneq (,$(strip NUT_SPELL_DICT))
+ ifneq (,$(strip $(NUT_SPELL_DICT)))
 export NUT_SPELL_DICT
 NUT_SPELL_DICT_OPTION = NUT_SPELL_DICT="$(NUT_SPELL_DICT)"
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -664,7 +664,7 @@ spellcheck-sortdict:
 	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/nut/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" $@
  else
 export NUT_SPELL_DICT
-NUT_SPELL_DICT_OPTION = NUT_SPELL_DICT="$(NUT_SPELL_DICT)"
+NUT_SPELL_DICT_OPTION = NUT_SPELL_DICT="../../$(strip $(NUT_SPELL_DICT))"
 
 # Find unique words in the sorted merged dictionary here vs. (pre-)sorted
 # dictionary file in NUT source - this difference is the sorted nut-website

--- a/Makefile.am
+++ b/Makefile.am
@@ -292,7 +292,7 @@ clean-local:
 		scripts/ups_data.js
 	git checkout -f images || true
 	rm -f *-spellchecked protocols/*-spellchecked nut-website.dict *.usage-report
-	rm -f nut-website.dict.bak-pre-sorting nut-website.dict.sorted .nut-website.dict.sorted
+	rm -f nut-website.dict.bak-pre-sorting nut-website.dict.sorted .nut-website.dict.sorted nut-website.dict.tmp
 	rm -f tools/nut-ddl.py tools/nut-hclinfo.py
 	rm -f historic-release.txt
 	rm -f .git-commit-website


### PR DESCRIPTION
Follow up for networkupstools/nut#2402 and #49 and #48

It seems that more trickery would be needed to properly hide GNU Make conditionals from Automake conditionals (there was similar work in bootstrap branch).