### PR TITLE
Introduce `htmlproofer` to sanity-check generated pages of the `nut-website`

### DIFF
--- a/Jenkinsfile-infra
+++ b/Jenkinsfile-infra
@@ -30,7 +30,16 @@ pipeline {
         booleanParam(
             name: 'CI_AVOID_SPELLCHECK',
             defaultValue: true,
-            description: 'If "true", the spellcheck of site files would be a separate action with a non-fatal diagnosis after a site build an push (best-effort FYI); if "false" then spelling issues vs. master nut/docs/nut.dict would be fatal before site build.'
+            description: 'If "true", the spellcheck of site files would be a separate action with a non-fatal diagnosis after a site build and push (best-effort FYI); if "false" then spelling issues vs. master nut/docs/nut.dict would be fatal before site build.'
+        )
+        choice(
+            name: 'CI_TRY_HTMLPROOFER',
+            // FIXME: Initially "false" to boot-strap development on
+            // https://github.com/networkupstools/nut-website/issues/52
+            // and then should become "true" or "require" depending on
+            // achievements.
+            choices: ['false', 'true', 'require'],
+            description: 'If "true", the sanity-check of generated site files (cross-page links etc.) would be an action with a non-fatal diagnosis after a site build before a push (best-effort FYI); if "require" its faults would be fatal; if "false" then we would not waste several minutes on it.'
         )
         booleanParam(
             name: 'NUT_DDL_PEDANTIC_DECLARATIONS',
@@ -106,7 +115,7 @@ pipeline {
 
                     def shRes
                     def msg
-                    echo "Starting website build: CI_AUTOCOMMIT=${env.CI_AUTOCOMMIT} CI_AUTOPUSH=${env.CI_AUTOPUSH} CI_AVOID_RESPIN=${env.CI_AVOID_RESPIN} CI_AVOID_SPELLCHECK=${env.CI_AVOID_SPELLCHECK} BRANCH_NAME=${env.BRANCH_NAME}"
+                    echo "Starting website build: CI_AUTOCOMMIT=${env.CI_AUTOCOMMIT} CI_AUTOPUSH=${env.CI_AUTOPUSH} CI_AVOID_RESPIN=${env.CI_AVOID_RESPIN} CI_AVOID_SPELLCHECK=${env.CI_AVOID_SPELLCHECK} CI_TRY_HTMLPROOFER=${env.CI_TRY_HTMLPROOFER} BRANCH_NAME=${env.BRANCH_NAME}"
                     withCredentials([gitUsernamePassword(credentialsId: scm.getUserRemoteConfigs()[0].getCredentialsId())]) {
                         // for git push in shell, using https://www.jenkins.io/blog/2021/07/27/git-credentials-binding-phase-1/
                         shRes = sh (returnStatus: true, script: "./ci_build.sh")

--- a/Makefile.am
+++ b/Makefile.am
@@ -173,6 +173,26 @@ all:	\
 	@cat .git-commit-website
 # Regenerate site 2020-12-21 vs nut commit 46c7da76 and nut-website commit f1992f6f
 
+if WITH_HTMLPROOFER
+check-htmlproofer: all
+	+@case "$(OUTDIR)" in \
+		"$(OUTDIR_BASE)"|"$(OUTDIR_BASE)/"*) $(MAKE) $(AM_MAKEFLAGS) check-htmlproofer-OUTDIR_BASE ;; \
+		*) $(MAKE) $(AM_MAKEFLAGS) check-htmlproofer-OUTDIR_BASE check-htmlproofer-OUTDIR ;; \
+	  esac
+
+check-htmlproofer-OUTDIR: $(OUTDIR)
+	$(HTMLPROOFER) $(OUTDIR)
+
+check-htmlproofer-OUTDIR_BASE: $(OUTDIR_BASE)
+	$(HTMLPROOFER) $(OUTDIR_BASE)
+
+else !WITH_HTMLPROOFER
+
+check-htmlproofer check-htmlproofer-OUTDIR check-htmlproofer-OUTDIR_BASE:
+	@echo "Do not have HTMLPROOFER on this system, skipped make target $@" >&2
+
+endif !WITH_HTMLPROOFER
+
 release: dist-files all
 
 # Generate WEBSITE_DEPS & HTML versions of man pages

--- a/Makefile.am
+++ b/Makefile.am
@@ -174,16 +174,23 @@ all:	\
 # Regenerate site 2020-12-21 vs nut commit 46c7da76 and nut-website commit f1992f6f
 
 if WITH_HTMLPROOFER
-check-htmlproofer: all
+
+# NOTE: We do not depend below on "all" or "OUTDIR" because that begins
+# rebuilds of the site we have possibly just made. Instead, these rules
+# just check whatever exists in the filesystem.
+
+check-htmlproofer:
 	+@case "$(OUTDIR)" in \
 		"$(OUTDIR_BASE)"|"$(OUTDIR_BASE)/"*) $(MAKE) $(AM_MAKEFLAGS) check-htmlproofer-OUTDIR_BASE ;; \
 		*) $(MAKE) $(AM_MAKEFLAGS) check-htmlproofer-OUTDIR_BASE check-htmlproofer-OUTDIR ;; \
 	  esac
 
-check-htmlproofer-OUTDIR: $(OUTDIR)
+check-htmlproofer-OUTDIR:
+	test -d $(OUTDIR)
 	$(HTMLPROOFER) $(OUTDIR)
 
-check-htmlproofer-OUTDIR_BASE: $(OUTDIR_BASE)
+check-htmlproofer-OUTDIR_BASE:
+	test -d $(OUTDIR_BASE)
 	$(HTMLPROOFER) $(OUTDIR_BASE)
 
 else !WITH_HTMLPROOFER

--- a/Makefile.am
+++ b/Makefile.am
@@ -179,6 +179,29 @@ if WITH_HTMLPROOFER
 # rebuilds of the site we have possibly just made. Instead, these rules
 # just check whatever exists in the filesystem.
 
+# * --disable_external
+#   By default, we avoid looking at remote website availability.
+#   This is something we may want to do occasionally (replace dead links
+#   by references to new incarnations or archive.org) but not take the
+#   performance hit (and annoy others) for every CI run - in that case
+#   consider a run with --external_only option to explicitly test that.
+# * --allow_hash_href
+#   We also allow <a href="#" ...> commonly used in javascript etc.
+# * --assume_extension
+#   allow extensionles urls (Jekyll3)
+HTMLPROOFER_OPTIONS_DEFAULT = \
+	--disable_external \
+	--allow_hash_href \
+	--assume_extension
+
+# CONSIDER:
+# * --empty_alt_ignore
+#   Temporarily allow empty alt tags on images
+# HTMLPROOFER_OPTIONS_DEFAULT += --empty_alt_ignore
+
+# Allow the caller an easy override:
+HTMLPROOFER_OPTIONS = $(HTMLPROOFER_OPTIONS_DEFAULT)
+
 check-htmlproofer:
 	+@case "$(OUTDIR)" in \
 		"$(OUTDIR_BASE)"|"$(OUTDIR_BASE)/"*) $(MAKE) $(AM_MAKEFLAGS) check-htmlproofer-OUTDIR_BASE ;; \
@@ -187,17 +210,17 @@ check-htmlproofer:
 
 check-htmlproofer-OUTDIR:
 	test -d $(OUTDIR)
-	$(HTMLPROOFER) $(OUTDIR)
+	$(HTMLPROOFER) $(HTMLPROOFER_OPTIONS) $(OUTDIR)
 
 check-htmlproofer-OUTDIR_BASE:
 	test -d $(OUTDIR_BASE)
-	$(HTMLPROOFER) $(OUTDIR_BASE)
+	$(HTMLPROOFER) $(HTMLPROOFER_OPTIONS) $(OUTDIR_BASE)
 
 # Fetched/updated via git checkout, e.g. by ci_build.sh
 OUTDIR_PUBLISHED = networkupstools.github.io
 check-htmlproofer-OUTDIR_PUBLISHED:
 	test -d $(OUTDIR_PUBLISHED)
-	$(HTMLPROOFER) $(OUTDIR_PUBLISHED)
+	$(HTMLPROOFER) $(HTMLPROOFER_OPTIONS) $(OUTDIR_PUBLISHED)
 
 else !WITH_HTMLPROOFER
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -199,8 +199,13 @@ HTMLPROOFER_OPTIONS_DEFAULT = \
 #   Temporarily allow empty alt tags on images
 # HTMLPROOFER_OPTIONS_DEFAULT += --empty_alt_ignore
 
+# Hide possible externally-rendered references to our own site (treat
+# them as relative starting with the slash):
+HTMLPROOFER_OPTIONS_URLSWAP = --url-swap='https?\://networkupstools\.github\.io:,https?\://networkupstools\.org:,https?\://www\.networkupstools\.org:'
+### HTMLPROOFER_OPTIONS_URLSWAP +=',https?\://[a-zA-Z0-9_.-]+\.networkupstools\.org:'
+
 # Allow the caller an easy override:
-HTMLPROOFER_OPTIONS = $(HTMLPROOFER_OPTIONS_DEFAULT)
+HTMLPROOFER_OPTIONS = $(HTMLPROOFER_OPTIONS_DEFAULT) $(HTMLPROOFER_OPTIONS_URLSWAP)
 
 check-htmlproofer:
 	+@case "$(OUTDIR)" in \

--- a/Makefile.am
+++ b/Makefile.am
@@ -193,6 +193,12 @@ check-htmlproofer-OUTDIR_BASE:
 	test -d $(OUTDIR_BASE)
 	$(HTMLPROOFER) $(OUTDIR_BASE)
 
+# Fetched/updated via git checkout, e.g. by ci_build.sh
+OUTDIR_PUBLISHED = networkupstools.github.io
+check-htmlproofer-OUTDIR_PUBLISHED:
+	test -d $(OUTDIR_PUBLISHED)
+	$(HTMLPROOFER) $(OUTDIR_PUBLISHED)
+
 else !WITH_HTMLPROOFER
 
 check-htmlproofer check-htmlproofer-OUTDIR check-htmlproofer-OUTDIR_BASE:

--- a/Makefile.am
+++ b/Makefile.am
@@ -222,7 +222,7 @@ check-htmlproofer-OUTDIR_BASE:
 	$(HTMLPROOFER) $(HTMLPROOFER_OPTIONS) $(OUTDIR_BASE)
 
 # Fetched/updated via git checkout, e.g. by ci_build.sh
-OUTDIR_PUBLISHED = networkupstools.github.io
+OUTDIR_PUBLISHED = $(abs_top_builddir)/networkupstools.github.io
 check-htmlproofer-OUTDIR_PUBLISHED:
 	test -d $(OUTDIR_PUBLISHED)
 	$(HTMLPROOFER) $(HTMLPROOFER_OPTIONS) $(OUTDIR_PUBLISHED)

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -69,6 +69,14 @@ or constrain the preference to nut-website builds:
 The `source-highlight` package is optional, but if available, will be used by
 AsciiDoc for syntax highlighting of examples.
 
+The optional `htmlproofer` tool from https://github.com/gjtorikian/html-proofer
+project can be used to sanity-check links and similar aspects of the markup in
+generated HTML pages. On Debian/Ubuntu systems you can install it as a package:
+
+----
+:; sudo apt-get install ruby-html-proofer
+----
+
 GNU `make` and GNU `coreutils` are recommended, but if you see any remaining
 non-portable constructs in the Makefiles, please let us know.
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -221,7 +221,8 @@ location for that repository, if not using the scripted default).
 
 Note that this check can take about 10 minutes (especially if not disabling
 the referenced external site availability), so it is not done by default.
-You can pass custom `HTMLPROOFER_OPTIONS` to the `make` operation, if desired.
+You can pass custom `HTMLPROOFER_OPTIONS` to the `make` operation, if desired;
+consider pasting the `HTMLPROOFER_OPTIONS_URLSWAP` in that case.
 
 Publishing
 ----------

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -204,6 +204,24 @@ there. You probably need to commit that back to "source" github repository.
 NOTE: For hardcore maintainers, there should be a PGP/GPG key to also sign the
 release tarball, calling `make dist-sig-files` (would fail without a key).
 
+Sanity-checking the generated HTML files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the `htmlproofer` tool is installed (see above) and detected by the
+`configure` script (automatically for presence in `PATH`), you can explicitly
+call `make check-htmlproofer` to validate the files present in `OUTDIR_BASE`
+and/or `OUTDIR` (if stored separately from the base for custom or historic
+website builds).
+
+You can also validate the published website repository (into which you would
+upload the generated `OUTDIR` contents) as e.g. prepared by the `ci_build.sh`
+using `make check-htmlproofer-OUTDIR_PUBLISHED` (optionally customize the
+`OUTDIR_PUBLISHED` environment or `make` variable to point to the checkout
+location for that repository, if not using the scripted default).
+
+Note that this check can take about 10 minutes (especially if not disabling
+the referenced external site availability), so it is not done by default.
+
 Publishing
 ----------
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -221,6 +221,7 @@ location for that repository, if not using the scripted default).
 
 Note that this check can take about 10 minutes (especially if not disabling
 the referenced external site availability), so it is not done by default.
+You can pass custom `HTMLPROOFER_OPTIONS` to the `make` operation, if desired.
 
 Publishing
 ----------

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -21,6 +21,16 @@
 [ x"${NUT_HISTORIC_RELEASE-}" != x ] || NUT_HISTORIC_RELEASE=""
 export CI_AUTOCOMMIT CI_AUTOPUSH CI_AVOID_RESPIN NUT_HISTORIC_RELEASE
 
+# FIXME: Initially "false" to boot-strap development on
+# https://github.com/networkupstools/nut-website/issues/52
+# and then should become "true" or "require" depending on
+# achievements.
+case x"${CI_TRY_HTMLPROOFER-}" in
+	xtrue|xfalse|xrequire) ;;
+	*) CI_TRY_HTMLPROOFER=false ;;
+esac
+export CI_TRY_HTMLPROOFER
+
 LANG=C
 LC_ALL=C
 TZ=UTC
@@ -71,6 +81,11 @@ case "${NUT_HISTORIC_RELEASE-}" in
 	{ make -k -j 8 ; echo "===== Finalize make:" >&2; make -s ; } || exit
 	;;
 esac
+
+if [ x"$CI_TRY_HTMLPROOFER" != xfalse ] ; then
+	echo "=== Sanity-checking the generated output directory..." >&2
+	make check-htmlproofer || if [ x"$CI_TRY_HTMLPROOFER" = xrequire ] ; then exit 1 ; fi
+fi
 
 # If we are here, there should be a populated "output" directory
 # and there were no build issues

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,27 @@ AC_PATH_PROGS([A2X], [a2x], [none])
 
 dnl ----------------------------------------------------------------------
 
+AC_PATH_PROGS([HTMLPROOFER], [htmlproofer html-proofer], [none])
+AC_ARG_WITH(htmlproofer,
+	[AS_HELP_STRING([--with-htmlproofer=PATH], [program location for htmlproofer (default: auto-detect)])],
+	[AS_CASE(["${withval}"],
+		[no|none], [
+			AS_IF([test x"${HTMLPROOFER}" != xnone], [AC_MSG_WARN([HTMLPROOFER='${HTMLPROOFER}' was detected, but we are explicitly configured to not use it])])
+			HTMLPROOFER="none"],
+		[''|auto|yes], [],
+		[HTMLPROOFER="${withval}"]
+	)],
+	[]
+)
+AM_CONDITIONAL([WITH_HTMLPROOFER], [test x"$HTMLPROOFER" != x -a x"$HTMLPROOFER" != xnone])
+AM_COND_IF([WITH_HTMLPROOFER], [
+	AC_MSG_CHECKING([if provided/detected HTMLPROOFER='${HTMLPROOFER}' is what it says it is])
+	LANG=C LC_ALL=C ${HTMLPROOFER} --help | grep -iE '^htmlproofer *@<:@0-9@:>@' || AC_MSG_ERROR([no])
+	AC_MSG_RESULT([yes])
+])
+
+dnl ----------------------------------------------------------------------
+
 dnl Note AC_INIT defines a constrained PACKAGE_VERSION based on last tag
 dnl in NUT codebase, not its configure.ac version or detailed revision.
 dnl For the rolling web-site we want to track origins more precisely:

--- a/nut-website.dict.addon
+++ b/nut-website.dict.addon
@@ -657,6 +657,7 @@ hcl
 highbattery
 highfrequency
 html
+htmlproofer
 ib
 ibattery
 icd
@@ -791,6 +792,7 @@ poweronmode
 powerontime
 powerouts
 pre
+proofer
 psu
 pulizzi
 pw

--- a/nut-website.dict.addon
+++ b/nut-website.dict.addon
@@ -448,6 +448,7 @@ UPScode
 UPSes
 UPSmon
 UPSs
+URLSWAP
 USVs
 UU
 UUU


### PR DESCRIPTION
Technical foundation to solve issue #52 and some initial fixes for the most-noisy findings.

Also minor fixes to spellchecking Makefile rules.

UPDATE: Changes not specific to `htmlproofer` were offloaded to PR #54, and this one was rebased over the resulting merge.