### PR TITLE
Fix `make spellcheck-interactive`, some m4 scripting, and a missing icon used by asciidoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ historic-release.txt
 *.usage-report
 /nut-website.dict
 /nut-website.dict.bak-pre-sorting
+/nut-website.dict.bak-pre-interactive
 /nut-website.dict.sorted
 /.nut-website.dict.sorted
 /nut-website.dict.tmp

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,10 @@ IMAGE_FILES =	\
 	images/simple.png	\
 	images/warning.png
 
+# Copied below from asciidoc resource location, if available
+IMAGE_FILES_ASCIIDOC_ICONS =	\
+	images/tip.png
+
 CABLE_IMAGE_FILES =	\
 	images/cables/73-0724.png	\
 	images/cables/940-0024C.jpg	\
@@ -149,6 +153,7 @@ all-files:	\
 	$(WEBSITE_FILES)	\
 	$(FAVICON_FILES)	\
 	$(IMAGE_FILES)	\
+	$(IMAGE_FILES_ASCIIDOC_ICONS)	\
 	$(CABLE_IMAGE_FILES)	\
 	$(LAYOUT_FILES)	\
 	$(SCRIPT_FILES)	\
@@ -222,6 +227,15 @@ $(WEBSITE_FILES): $(LAYOUT).conf historic-release.txt
 
 images/:
 	$(MKDIR_P) images
+
+# FIXME: Detect location via configure script?
+# The file would be published at least once to the ultimate site...
+$(IMAGE_FILES_ASCIIDOC_ICONS): images/
+	if [ -d /usr/share/asciidoc ]; then \
+		find /usr/share/asciidoc -name "$(@F)" -exec cp -f '{}' images/ \; ; \
+	else \
+		echo "Can not find ASCIIDOC resource location, skipped $@" ; \
+	fi
 
 $(IMAGE_FILES): images/
 	cp -f nut/docs/$@ images/

--- a/Makefile.am
+++ b/Makefile.am
@@ -298,7 +298,7 @@ clean-local:
 		scripts/ups_data.js
 	git checkout -f images || true
 	rm -f *-spellchecked protocols/*-spellchecked nut-website.dict *.usage-report
-	rm -f nut-website.dict.bak-pre-sorting nut-website.dict.sorted .nut-website.dict.sorted nut-website.dict.tmp
+	rm -f nut-website.dict.bak-pre-sorting nut-website.dict.sorted .nut-website.dict.sorted nut-website.dict.tmp nut-website.bak-pre-interactive
 	rm -f tools/nut-ddl.py tools/nut-hclinfo.py
 	rm -f historic-release.txt
 	rm -f .git-commit-website
@@ -680,12 +680,15 @@ nut-website.dict: $(top_builddir)/nut/docs/nut.dict nut-website.dict.addon
 
 # Indented GNUmake "if/else/endif"
 # HIDE FROM AUTOMAKE # ifeq (,$(strip $(NUT_SPELL_DICT)))
+# HIDE FROM AUTOMAKE #
 # HIDE FROM AUTOMAKE ## Pass to original NUT recipe and its dict file alone
 # HIDE FROM AUTOMAKE #NUT_SPELL_DICT_OPTION =
-# HIDE FROM AUTOMAKE #spellcheck-sortdict:
+# HIDE FROM AUTOMAKE #spellcheck-sortdict spellcheck-interactive:
 # HIDE FROM AUTOMAKE #	@echo "$@ for NUT-source-only NUT_SPELL_DICT (NUT_SPELL_DICT_DEBUGTAG=$(NUT_SPELL_DICT_DEBUGTAG))" >&2
 # HIDE FROM AUTOMAKE #	+cd "$(abs_top_builddir)/nut/docs/" && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_SRC="$(addprefix ../../,$(SPELLCHECK_SRC))" $@
+# HIDE FROM AUTOMAKE #
 # HIDE FROM AUTOMAKE # else
+# HIDE FROM AUTOMAKE #
 # HIDE FROM AUTOMAKE #export NUT_SPELL_DICT
 # HIDE FROM AUTOMAKE #NUT_SPELL_DICT_OPTION = NUT_SPELL_DICT="../../$(notdir $(strip $(NUT_SPELL_DICT)))" NUT_SPELL_DICT_ABS="$(abs_top_builddir)/$(notdir $(strip $(NUT_SPELL_DICT)))"
 # HIDE FROM AUTOMAKE #
@@ -699,10 +702,19 @@ nut-website.dict: $(top_builddir)/nut/docs/nut.dict nut-website.dict.addon
 # HIDE FROM AUTOMAKE #		> nut-website.dict.addon.sorted
 # HIDE FROM AUTOMAKE #	@test -s nut-website.dict.addon.sorted || { echo "ERROR: $@ for NUT_SPELL_DICT=$< yielded an empty file; we expect some unique words here!" >&2; exit 1; }
 # HIDE FROM AUTOMAKE #	@mv -f nut-website.dict.addon.sorted "$(abs_top_srcdir)/nut-website.dict.addon"
+# HIDE FROM AUTOMAKE #
+# HIDE FROM AUTOMAKE #spellcheck-interactive: $(NUT_SPELL_DICT)
+# HIDE FROM AUTOMAKE #	@echo "$@ for NUT_SPELL_DICT=$< (NUT_SPELL_DICT_DEBUGTAG=$(NUT_SPELL_DICT_DEBUGTAG))" >&2
+# HIDE FROM AUTOMAKE #	cp -f "$(NUT_SPELL_DICT)" "$(NUT_SPELL_DICT).bak-pre-interactive"
+# HIDE FROM AUTOMAKE #	+cd "$(abs_top_builddir)/nut/docs/" && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_SRC="$(addprefix ../../,$(SPELLCHECK_SRC))" $(NUT_SPELL_DICT_OPTION) $@
+# HIDE FROM AUTOMAKE #	diff -bu "$(NUT_SPELL_DICT).bak-pre-interactive" "$(NUT_SPELL_DICT)" | grep -E '^\+[^\+]' | sed 's/^\+//' | grep -vE '^personal_ws' >> "$(abs_top_srcdir)/nut-website.dict.addon"
+# HIDE FROM AUTOMAKE #	rm -f "$(NUT_SPELL_DICT).bak-pre-interactive"
+# HIDE FROM AUTOMAKE #	+$(MAKE) $(AM_MAKEFLAGS) spellcheck-sortdict-addon
+# HIDE FROM AUTOMAKE #
 # HIDE FROM AUTOMAKE # endif
 
 # Whether we have a custom dictionary or not:
-spellcheck spellcheck-interactive spellcheck-report-dict-usage: $(NUT_SPELL_DICT)
+spellcheck spellcheck-report-dict-usage: $(NUT_SPELL_DICT)
 	@echo "$@ for NUT_SPELL_DICT=$< (NUT_SPELL_DICT_DEBUGTAG=$(NUT_SPELL_DICT_DEBUGTAG))" >&2
 	+cd "$(abs_top_builddir)/nut/docs/" && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_SRC="$(addprefix ../../,$(SPELLCHECK_SRC))" $(NUT_SPELL_DICT_OPTION) $@
 

--- a/configure.ac
+++ b/configure.ac
@@ -74,9 +74,9 @@ AX_COMPARE_VERSION([${DBLATEX_VERSION}], [ge], [0.2.5], [
 	AC_MSG_ERROR(["Unable to build website: check dblatex!"])
 ])
 ], [AC_MSG_NOTICE([Newer NUT sources are in use and suitability of asciidoc and other tools was already tested])
-    AS_IF([test "${nut_have_asciidoc}" = "no"],[
-	AC_MSG_ERROR(["Unable to build website: check asciidoc and other tools versions!"])
-    ])
+	AS_IF([test "${nut_have_asciidoc}" = "no"], [
+		AC_MSG_ERROR(["Unable to build website: check asciidoc and other tools versions!"])
+	])
 ])
 
 dnl ----------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -89,9 +89,9 @@ dnl ----------------------------------------------------------------------
 dnl Note AC_INIT defines a constrained PACKAGE_VERSION based on last tag
 dnl in NUT codebase, not its configure.ac version or detailed revision.
 dnl For the rolling web-site we want to track origins more precisely:
-NUT_VERSION="$(cd nut && (git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]' --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' || git describe --tags --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' --exclude '*Windows*' --exclude '*IPM*' ) 2>/dev/null )"
-DDL_VERSION="$(cd ddl && (git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]' --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' || git describe --tags --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' --exclude '*Windows*' --exclude '*IPM*' ) 2>/dev/null )"
-WEB_VERSION="$( (git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]' --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' || git describe --tags --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' --exclude '*Windows*' --exclude '*IPM*' ) 2>/dev/null )"
+NUT_VERSION="$(cd nut && (git describe --tags --match 'v@<:@0-9@:>@*.@<:@0-9@:>@*.@<:@0-9@:>@' --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' || git describe --tags --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' --exclude '*Windows*' --exclude '*IPM*' ) 2>/dev/null )"
+DDL_VERSION="$(cd ddl && (git describe --tags --match 'v@<:@0-9@:>@*.@<:@0-9@:>@*.@<:@0-9@:>@' --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' || git describe --tags --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' --exclude '*Windows*' --exclude '*IPM*' ) 2>/dev/null )"
+WEB_VERSION="$( (git describe --tags --match 'v@<:@0-9@:>@*.@<:@0-9@:>@*.@<:@0-9@:>@' --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' || git describe --tags --exclude '*-signed' --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*' --exclude '*Windows*' --exclude '*IPM*' ) 2>/dev/null )"
 WEB_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
 WEBSITE_VERSION="${PACKAGE_VERSION}"
 AS_CASE(["${NUT_VERSION}"],


### PR DESCRIPTION
Offloaded from #53 as points unrelated to `htmlproofer` specifically - but found and fixed during work on #52